### PR TITLE
feat: Print "Tax Exemption Reason" if present in the document

### DIFF
--- a/print_format/quotation.jinja
+++ b/print_format/quotation.jinja
@@ -196,6 +196,16 @@
                         </tr>
                     {% endif %}
                 {%- endfor %}
+
+                {% if doc.tax_exemption_reason %}
+                    <tr>
+                        <td></td>
+                        <td>{{ _(doc.tax_exemption_reason) }}</td>
+                        <td></td>
+                        <td></td>
+                        <td colspan="2"></td>
+                    </tr>
+                {% endif %}
             {%- endif %}
             <tr>
                 <td></td>

--- a/print_format/sales_invoice.jinja
+++ b/print_format/sales_invoice.jinja
@@ -205,6 +205,16 @@
                         </tr>
                     {% endif %}
                 {%- endfor %}
+
+                {% if doc.tax_exemption_reason %}
+                    <tr>
+                        <td></td>
+                        <td>{{ _(doc.tax_exemption_reason) }}</td>
+                        <td></td>
+                        <td></td>
+                        <td colspan="2"></td>
+                    </tr>
+                {% endif %}
             {%- endif %}
             <tr>
                 <td></td>

--- a/print_format/sales_order.jinja
+++ b/print_format/sales_order.jinja
@@ -209,6 +209,16 @@
                         </tr>
                   {% endif %}
                 {%- endfor %}
+
+                {% if doc.tax_exemption_reason %}
+                    <tr>
+                        <td></td>
+                        <td>{{ _(doc.tax_exemption_reason) }}</td>
+                        <td></td>
+                        <td></td>
+                        <td colspan="2"></td>
+                    </tr>
+                {% endif %}
             {%- endif %}
             <tr>
                 <td></td>


### PR DESCRIPTION
- Works with and without `erpnext_germany` (Ref: https://github.com/alyf-de/erpnext_germany/pull/8)
- Will check if `tax_exemption_reason` is available in the document and only render this row if it is

Preview: https://github.com/alyf-de/druckformate_dacherp/pull/20