### PR TITLE
Fix: Display customer_name only if customer is a company

### DIFF
--- a/print_format/dunning.jinja
+++ b/print_format/dunning.jinja
@@ -35,7 +35,9 @@
                 {%- endif %}
             </p>
         </div>
+        {% if frappe.db.get_value("Customer", sales_invoice.customer_name, "customer_type") == "Company"%}
         {{ sales_invoice.customer_name }}<br />
+        {% endif %}
         {% if contact %}
                 {%- if contact.salutation -%}
                     {{ _(contact.salutation) }}

--- a/print_format/quotation.jinja
+++ b/print_format/quotation.jinja
@@ -36,7 +36,9 @@
             </p>
         </div>
         {% endif %}
+        {% if frappe.db.get_value("Customer", doc.customer_name, "customer_type") == "Company"%}
         {{ doc.customer_name }}<br />
+        {% endif %}
         {% if contact %}
                 {%- if contact.salutation -%}
                     {{ contact.salutation }}

--- a/print_format/sales_invoice.jinja
+++ b/print_format/sales_invoice.jinja
@@ -36,7 +36,9 @@
             </p>
         </div>
         {% endif %}
+        {% if frappe.db.get_value("Customer", doc.customer_name, "customer_type") == "Company"%}
         {{ doc.customer_name }}<br />
+        {% endif %}
         {% if contact %}
                 {%- if contact.salutation -%}
                     {{ contact.salutation }}

--- a/print_format/sales_order.jinja
+++ b/print_format/sales_order.jinja
@@ -36,7 +36,9 @@
             </p>
         </div>
         {% endif %}
+        {% if frappe.db.get_value("Customer", doc.customer_name, "customer_type") == "Company"%}
         {{ doc.customer_name }}<br />
+        {% endif %}
         {% if contact %}
                 {%- if contact.salutation -%}
                     {{ contact.salutation }}


### PR DESCRIPTION
Damit beim Erstellen von Rechnungen für Einzelpersonen nicht der `customer_name` und der Name vom `contact` angezeigt wird, hab ich eine simple Abfrage hinzugefügt.