### PR TITLE
fix: :art: corrected width of address feld

### DIFF
--- a/print_style/print_style.scss
+++ b/print_style/print_style.scss
@@ -38,7 +38,7 @@
 
     #address {
         float: left;
-        width: 85mm;
+        width: 80mm;
         padding-left: 5mm;
     }
 
@@ -60,12 +60,13 @@
         height: 1pt;
         background-color: black;
         position: absolute;
+        left: 2mm;
     }
 
     #faltmarke-1 {
         /* ( 105 mm - 10 mm margin ) */
         top: 95mm;
-        width: 12mm;
+        width: 5mm;
     }
 
     #lochmarke {
@@ -77,7 +78,7 @@
     #faltmarke-2 {
         /* ( 210 mm - 10 mm margin ) */
         top: 200mm;
-        width: 12mm;
+        width: 5mm;
     }
 
     #text {


### PR DESCRIPTION
- the width of the address feld is 85mm and set correctly but in the din 5008 the text of the address starts with an offset of 5mm. therfore the margin is set to 25 insted of 20. this results in to an width of 80 for the address feld insted of 85mm.
- have a little offset for the folding marks of 2mm